### PR TITLE
1.20.1 - Add gradual moon phase darkness 

### DIFF
--- a/src/main/java/grondag/darkness/Darkness.java
+++ b/src/main/java/grondag/darkness/Darkness.java
@@ -57,6 +57,7 @@ public class Darkness {
 	static boolean darkSkyless;
 	static boolean blockLightOnly;
 	static boolean ignoreMoonPhase;
+	static boolean gradualMoonPhaseDarkness;
 	static boolean invertBiomeDarkness;
 	public static JsonObject darknessBiomes;
 
@@ -101,6 +102,7 @@ public class Darkness {
 		}
 
 		ignoreMoonPhase = properties.computeIfAbsent("ignore_moon_phase", (a) -> "false").equals("true");
+		gradualMoonPhaseDarkness = properties.computeIfAbsent("gradual_moon_phase_darkness", (a) -> "false").equals("true");
 		blockLightOnly = properties.computeIfAbsent("only_affect_block_light", (a) -> "false").equals("true");
 		darkOverworld = properties.computeIfAbsent("dark_overworld", (a) -> "true").equals("true");
 		darkDefault = properties.computeIfAbsent("dark_default", (a) -> "true").equals("true");
@@ -162,6 +164,7 @@ public class Darkness {
 
 		properties.put("only_affect_block_light", Boolean.toString(blockLightOnly));
 		properties.put("ignore_moon_phase", Boolean.toString(ignoreMoonPhase));
+		properties.put("gradual_moon_phase_darkness", Boolean.toString(gradualMoonPhaseDarkness));
 		properties.put("dark_overworld", Boolean.toString(darkOverworld));
 		properties.put("dark_default", Boolean.toString(darkDefault));
 		properties.put("dark_nether", Boolean.toString(darkNether));
@@ -226,7 +229,8 @@ public class Darkness {
 				if (angle > 0.25f && angle < 0.75f) {
 					final float oldWeight = Math.max(0, (Math.abs(angle - 0.5f) - 0.2f)) * 20;
 					final float moon = ignoreMoonPhase ? 0 : world.getMoonBrightness();
-					return Mth.lerp(oldWeight * oldWeight * oldWeight, moon * moon, 1f);
+					final float moonBrightness = gradualMoonPhaseDarkness ? moon : moon * moon;
+					return Mth.lerp(oldWeight * oldWeight * oldWeight, moonBrightness, 1f);
 				} else {
 					return 1;
 				}

--- a/src/main/java/grondag/darkness/DarknessConfigScreen.java
+++ b/src/main/java/grondag/darkness/DarknessConfigScreen.java
@@ -34,6 +34,7 @@ public class DarknessConfigScreen extends Screen {
 
 	protected Checkbox blockLightOnlyWidget;
 	protected Checkbox ignoreMoonPhaseWidget;
+	protected Checkbox gradualMoonPhaseDarkness;
 	protected Checkbox darkOverworldWidget;
 	protected Checkbox darkNetherWidget;
 	protected Checkbox darkEndWidget;
@@ -57,7 +58,7 @@ public class DarknessConfigScreen extends Screen {
 
 	@Override
 	protected void init() {
-		int i = 27;
+		int i = 23;
 		blockLightOnlyWidget = new Checkbox(width / 2 - 100, i, 200, 20, Component.translatable("config.darkness.label.block_light_only"), Darkness.blockLightOnly) {
 			@Override
 			public void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float delta) {
@@ -69,7 +70,7 @@ public class DarknessConfigScreen extends Screen {
 			}
 		};
 
-		i += 27;
+		i += 23;
 
 		ignoreMoonPhaseWidget = new Checkbox(width / 2 - 100, i, 200, 20, Component.translatable("config.darkness.label.ignore_moon_phase"), Darkness.ignoreMoonPhase) {
 			@Override
@@ -82,7 +83,20 @@ public class DarknessConfigScreen extends Screen {
 			}
 		};
 
-		i += 27;
+		i += 23;
+
+		gradualMoonPhaseDarkness = new Checkbox(width / 2 - 100, i, 200, 20, Component.translatable("config.darkness.label.gradual_moon_phase_darkness"), Darkness.gradualMoonPhaseDarkness) {
+			@Override
+			public void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float delta) {
+				super.renderWidget(guiGraphics, mouseX, mouseY, delta);
+
+				if (isHovered) {
+					guiGraphics.renderTooltip(DarknessConfigScreen.this.minecraft.font, Component.translatable("config.darkness.help.gradual_moon_phase_darkness"), mouseX, mouseY);
+				}
+			}
+		};
+
+		i += 23;
 
 		darkOverworldWidget = new Checkbox(width / 2 - 100, i, 200, 20, Component.translatable("config.darkness.label.dark_overworld"), Darkness.darkOverworld) {
 			@Override
@@ -95,7 +109,7 @@ public class DarknessConfigScreen extends Screen {
 			}
 		};
 
-		i += 27;
+		i += 23;
 
 		darkNetherWidget = new Checkbox(width / 2 - 100, i, 200, 20, Component.translatable("config.darkness.label.dark_nether"), Darkness.darkNether) {
 			@Override
@@ -108,7 +122,7 @@ public class DarknessConfigScreen extends Screen {
 			}
 		};
 
-		i += 27;
+		i += 23;
 
 		darkEndWidget = new Checkbox(width / 2 - 100, i, 200, 20, Component.translatable("config.darkness.label.dark_end"), Darkness.darkEnd) {
 			@Override
@@ -121,7 +135,7 @@ public class DarknessConfigScreen extends Screen {
 			}
 		};
 
-		i += 27;
+		i += 23;
 
 		darkDefaultWidget = new Checkbox(width / 2 - 100, i, 200, 20, Component.translatable("config.darkness.label.dark_default"), Darkness.darkDefault) {
 			@Override
@@ -134,7 +148,7 @@ public class DarknessConfigScreen extends Screen {
 			}
 		};
 
-		i += 27;
+		i += 23;
 
 		darkSkylessWidget = new Checkbox(width / 2 - 100, i, 200, 20, Component.translatable("config.darkness.label.dark_skyless"), Darkness.darkSkyless) {
 			@Override
@@ -147,10 +161,11 @@ public class DarknessConfigScreen extends Screen {
 			}
 		};
 
-		i += 27;
+		i += 23;
 
 		addRenderableWidget(blockLightOnlyWidget);
 		addRenderableWidget(ignoreMoonPhaseWidget);
+		addRenderableWidget(gradualMoonPhaseDarkness);
 		addRenderableWidget(darkOverworldWidget);
 		addRenderableWidget(darkNetherWidget);
 		addRenderableWidget(darkEndWidget);
@@ -160,6 +175,7 @@ public class DarknessConfigScreen extends Screen {
 		addRenderableWidget(Button.builder(CommonComponents.GUI_DONE, (buttonWidget) -> {
 			Darkness.blockLightOnly = blockLightOnlyWidget.selected();
 			Darkness.ignoreMoonPhase = ignoreMoonPhaseWidget.selected();
+			Darkness.gradualMoonPhaseDarkness = gradualMoonPhaseDarkness.selected();
 			Darkness.darkOverworld = darkOverworldWidget.selected();
 			Darkness.darkNether = darkNetherWidget.selected();
 			Darkness.darkEnd = darkEndWidget.selected();
@@ -167,7 +183,7 @@ public class DarknessConfigScreen extends Screen {
 			Darkness.darkSkyless = darkSkylessWidget.selected();
 			Darkness.saveConfig();
 			minecraft.setScreen(parent);
-		}).bounds(width / 2 - 100, height - 27, 200, 20).build());
+		}).bounds(width / 2 - 100, height - 23, 200, 20).build());
 	}
 
 	@Override

--- a/src/main/resources/assets/darkness/lang/en_us.json
+++ b/src/main/resources/assets/darkness/lang/en_us.json
@@ -6,6 +6,9 @@
 	
 	"config.darkness.label.ignore_moon_phase": "Ignore Moon Phase",
 	"config.darkness.help.ignore_moon_phase": "Night is truly dark even when the moon is full",
+
+	"config.darkness.label.gradual_moon_phase_darkness": "Gradual Moon Phase Darkness",
+	"config.darkness.help.gradual_moon_phase_darkness": "Nights get darker more gradually as moon changes phase",
 	
 	"config.darkness.label.dark_overworld": "Dark Overworld",
 	"config.darkness.help.dark_overworld": "Enable in Overworld",


### PR DESCRIPTION
Add gradual moon phase darkness transition as a config option.
Nights will get darker more gradually as the moon phase transitions from full moon to new moon.

![true-dark-gradual-comparison](https://github.com/user-attachments/assets/42536db5-e3d4-4e20-babe-fac172334397)
 ^ For comparison, without and with the config option enabled.